### PR TITLE
feature: enable recommended virtual dom lint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,3 +1,16 @@
 import * as config from '@lvce-editor/eslint-config'
 
-export default [...config.default]
+export default [
+  ...config.default,
+  ...config.recommendedVirtualDom,
+  {
+    files: ['packages/iframe-inspector/test/**/*.ts'],
+    rules: {
+      'virtual-dom/no-inline-event-handlers': 'off',
+      'virtual-dom/no-object-attribute-values': 'off',
+      'virtual-dom/prefer-constants': 'off',
+      'virtual-dom/prefer-merge-class-names': 'off',
+      'virtual-dom/prefer-state-destructuring': 'off',
+    },
+  },
+]

--- a/packages/iframe-inspector/src/parts/GetSavedFilterText/GetSavedFilterText.ts
+++ b/packages/iframe-inspector/src/parts/GetSavedFilterText/GetSavedFilterText.ts
@@ -1,6 +1,7 @@
 export const getSavedFilterText = (state: unknown): string => {
   if (state && typeof state === 'object' && 'filterText' in state && typeof state['filterText'] === 'string') {
-    return state.filterText
+    const { filterText } = state
+    return filterText
   }
   return ''
 }

--- a/packages/iframe-inspector/src/parts/GetTableWrapperVirtualDom/GetTableWrapperVirtualDom.ts
+++ b/packages/iframe-inspector/src/parts/GetTableWrapperVirtualDom/GetTableWrapperVirtualDom.ts
@@ -5,6 +5,7 @@ import * as DomEventListeners from '../DomEventListeners/DomEventListeners.ts'
 import * as GetNoMessagesFoundVirtualDom from '../GetNoMessagesFoundVirtualDom/GetNoMessagesFoundVirtualDom.ts'
 import * as GetTableVirtualDom from '../GetTableVirtualDom/GetTableVirtualDom.ts'
 import * as Role from '../Role/Role.ts'
+import * as TabIndex from '../TabIndex/TabIndex.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 
 const parentNode: VirtualDomNode = {
@@ -26,7 +27,7 @@ export const getTableWrapperVirtualDom = (messages: readonly MessageViewModel[],
       onBlur: DomEventListeners.HandleListBlur,
       onFocusIn: DomEventListeners.HandleListFocus,
       role: Role.Application,
-      tabIndex: 0,
+      tabIndex: TabIndex.Focusable,
       type: VirtualDomElements.Div,
     },
     ...GetTableVirtualDom.getTableVirtualDom(messages, columnWidths),

--- a/packages/iframe-inspector/src/parts/MessageState/MessageState.ts
+++ b/packages/iframe-inspector/src/parts/MessageState/MessageState.ts
@@ -7,11 +7,13 @@ const state: State = {
 }
 
 export const addMessage = (message: any): void => {
-  state.messages = [...state.messages, message]
+  const { messages } = state
+  state.messages = [...messages, message]
 }
 
 export const getMessages = (): readonly any[] => {
-  return state.messages
+  const { messages } = state
+  return messages
 }
 
 export const reset = (): void => {

--- a/packages/iframe-inspector/src/parts/TabIndex/TabIndex.ts
+++ b/packages/iframe-inspector/src/parts/TabIndex/TabIndex.ts
@@ -1,0 +1,1 @@
+export const Focusable = 0

--- a/packages/iframe-inspector/src/parts/TokenParentNodes/TokenParentNodes.ts
+++ b/packages/iframe-inspector/src/parts/TokenParentNodes/TokenParentNodes.ts
@@ -1,10 +1,11 @@
 import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
+import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 
 const createTokenNode = (className: string): VirtualDomNode => {
   return {
     childCount: 1,
-    className: `Token ${className}`,
+    className: MergeClassNames.mergeClassNames('Token', className),
     type: VirtualDomElements.Span,
   }
 }


### PR DESCRIPTION
## Summary
- enable the recommended virtual DOM ESLint configuration
- fix production virtual DOM lint findings
- keep fixture-focused exceptions scoped to iframe-inspector tests

## Validation
- npm run lint
- npm run build
- npm run type-check
- npm test (99 tests)
- npm run measure