### PR TITLE
fix: update GitHub Pages actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Upload artifact
         if: matrix.os == 'ubuntu-24.04'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./.tmp/static
       - name: Clean up
@@ -78,4 +78,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Update the GitHub Pages upload and deploy actions to their current supported majors.